### PR TITLE
Small bug fixes in HTTP Server and app title

### DIFF
--- a/main.js
+++ b/main.js
@@ -116,6 +116,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 2000,
     height: 1000,
+    title: 'Swell',
     minWidth: 1000,
     minHeight: 600,
     backgroundColor: '-webkit-linear-gradient(top, #3dadc2 0%,#2f4858 100%)',

--- a/test/httpServer.js
+++ b/test/httpServer.js
@@ -3,7 +3,7 @@ const bodyParser = require('body-parser');
 
 const app = express();
 
-const PORT = 3000;
+const PORT = process.env.NODE_ENV === 'test' ? 3004 : 3000;
 
 let mockDB = [];
 
@@ -15,58 +15,55 @@ app.get('/clear', (req, res) => {
   res.sendStatus(200);
 });
 
-app.get('/book', (req, res) =>
-  res.status(200).json(mockDB)
-);
+app.get('/book', (req, res) => res.status(200).json(mockDB));
 
-app.post('/book', (req, res) =>{
+app.post('/book', (req, res) => {
   const { title, author, pages } = req.body;
   const book = { title, author, pages };
-  mockDB.push(book)
-  res.status(200).json(book)
+  mockDB.push(book);
+  res.status(200).json(book);
 });
-  
 
 app.put('/book/:title', (req, res) => {
   const { title } = req.params;
   const { author, pages } = req.body;
   let index;
-  mockDB.forEach((book, i)=>{
-    if (book.title = title){
+  mockDB.forEach((book, i) => {
+    if ((book.title = title)) {
       book.title = title;
       book.author = author;
       book.pages = pages;
       index = i;
     }
-  }) 
-  res.status(200).json(mockDB[index])
+  });
+  res.status(200).json(mockDB[index]);
 });
 
-app.patch('/book/:title', (req, res) =>{
+app.patch('/book/:title', (req, res) => {
   const { title } = req.params;
   const { author } = req.body;
   let index;
-  mockDB.forEach((book, i)=>{
-    if (book.title = title){
+  mockDB.forEach((book, i) => {
+    if ((book.title = title)) {
       book.title = title;
       book.author = author;
       index = i;
     }
-  }) 
-  res.status(200).json(mockDB[index])
+  });
+  res.status(200).json(mockDB[index]);
 });
 
-app.delete('/book/:title', (req, res) =>{
-  let targetBook
+app.delete('/book/:title', (req, res) => {
+  let targetBook;
   const { title } = req.params;
-  mockDB.forEach((book, i)=>{
-    if (book.title = title){
+  mockDB.forEach((book, i) => {
+    if ((book.title = title)) {
       targetBook = book;
-      mockDB = mockDB.slice(0,i).concat(mockDB.slice(i+1))
+      mockDB = mockDB.slice(0, i).concat(mockDB.slice(i + 1));
       index = i;
     }
-  }) 
-  res.status(200).json(targetBook)
+  });
+  res.status(200).json(targetBook);
 });
 
 const httpApp = app.listen(PORT, () => {


### PR DESCRIPTION
If Mocha tests are run, the production app UI uses port 3000. In that case, HTTP server cannot use the same port or else it will impede the electron app from opening.

Note that this does not completely fix `npm run test`, since many tests within the suite is obsolete and requires rewriting to using the current UI component paths.

For some reason, the app's title for production is not capitalized. This enforces the app has a title with first letter capitalized