### PR TITLE
Add ability to unsubscribe GraphQL subscription

### DIFF
--- a/src/client/components/legacy-components/SingleReqResContainer.jsx
+++ b/src/client/components/legacy-components/SingleReqResContainer.jsx
@@ -326,12 +326,7 @@ const SingleReqResContainer = (props) => {
               }
               // console.log(content)
               connectionController.openReqRes(content.id);
-              dispatch(
-                responseDataSaved(
-                  content,
-                  'singleReqResContainercomponentSendHandler'
-                )
-              ); //dispatch will fire first before the callback of [ipcMain.on('open-ws'] is fired. check async and callback queue concepts
+              dispatch(responseDataSaved(content)); //dispatch will fire first before the callback of [ipcMain.on('open-ws'] is fired. check async and callback queue concepts
             }}
           >
             Send

--- a/src/client/components/legacy-components/SingleScheduleReqResContainer.jsx
+++ b/src/client/components/legacy-components/SingleScheduleReqResContainer.jsx
@@ -36,9 +36,7 @@ const SingleScheduleReqResContainer = (props) => {
     currentResponse.id === content.id ? getBorderClass(currentResponse) : '';
 
   useEffect(() => {
-    dispatch(
-      responseDataSaved(content, 'SingleScheduleReqResContainerComponent')
-    );
+    dispatch(responseDataSaved(content));
   }, [content, dispatch]);
 
   return (

--- a/src/client/components/main/http2-composer/Http2Composer.tsx
+++ b/src/client/components/main/http2-composer/Http2Composer.tsx
@@ -181,9 +181,7 @@ export default function Http2Composer(props) {
     dispatch(setSidebarActiveTab('composer'));
 
     connectionController.openReqRes(reqRes.id);
-    dispatch(
-      responseDataSaved(reqRes, 'singleReqResContainercomponentSendHandler')
-    );
+    dispatch(responseDataSaved(reqRes));
   };
 
   /** @todo Figure out what this function does */

--- a/src/client/controllers/reqResController.ts
+++ b/src/client/controllers/reqResController.ts
@@ -52,7 +52,7 @@ const connectionController = {
       /** @todo Find where id should be */
       const currentID = Store.getState().reqRes.currentResponse.id;
       if (currentID === reqResObj.id) {
-        appDispatch(responseDataSaved(reqResObj, 'currentID===reqResObj.id'));
+        appDispatch(responseDataSaved(reqResObj));
       }
     });
     // Since only obj ID is passed in, next two lines get the current array of request objects and finds the one with matching ID
@@ -147,7 +147,7 @@ const connectionController = {
       }
       appDispatch(reqResUpdated(reqResObj));
 
-      appDispatch(responseDataSaved(reqResObj, 'api.receive reqresupdate'));
+      appDispatch(responseDataSaved(reqResObj));
       if (index < reqResArray.length) {
         runSingletest(reqResArray[index]);
         index += 1;
@@ -204,9 +204,7 @@ const connectionController = {
 
     foundReqRes.connection = 'closed';
     appDispatch(reqResUpdated(foundReqRes));
-    appDispatch(
-      responseDataSaved(foundReqRes, 'foundreqres.connection closed')
-    );
+    appDispatch(responseDataSaved(foundReqRes));
   },
 
   closeReqRes(reqResObj: ReqRes): void {

--- a/src/client/controllers/reqResController.ts
+++ b/src/client/controllers/reqResController.ts
@@ -14,7 +14,7 @@ import {
 } from '../toolkit-refactor/graphPoints/graphPointsSlice';
 
 import graphQLController from './graphQLController';
-import { ReqRes, WindowAPI, WindowExt } from '../../types';
+import { ReqRes, WindowExt } from '../../types';
 
 const { api } = window as unknown as WindowExt;
 const connectionController = {
@@ -37,11 +37,13 @@ const connectionController = {
     api.removeAllListeners('reqResUpdate');
 
     api.receive('reqResUpdate', (reqResObj: ReqRes) => {
-      if ((reqResObj.connection === 'closed' ||
-        reqResObj.connection === 'error') &&
+      if (
+        (reqResObj.connection === 'closed' ||
+          reqResObj.connection === 'error') &&
         reqResObj.timeSent &&
         reqResObj.timeReceived &&
-        reqResObj.response.events.length > 0) {
+        reqResObj.response.events.length > 0
+      ) {
         appDispatch(graphUpdated(reqResObj));
       }
       appDispatch(reqResUpdated(reqResObj));
@@ -210,26 +212,15 @@ const connectionController = {
   closeReqRes(reqResObj: ReqRes): void {
     if (reqResObj.protocol.includes('http')) {
       api.send('close-http', reqResObj);
+    } else if (
+      reqResObj.graphQL &&
+      reqResObj.request?.method === 'SUBSCRIPTION'
+    ) {
+      graphQLController.closeSubscription(reqResObj);
     }
 
     const { id } = reqResObj;
     this.setReqResConnectionToClosed(id);
-
-    // We are pretty sure that this code block is never executed... -Prince
-    // // WS is the only protocol using openConnectionArray
-    // const foundAbortController = this.openConnectionArray.find(
-    //   // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type 'never'.
-    //   (obj) => obj.id === id
-    // );
-    // // @ts-expect-error ts-migrate(2339) FIXME: Property 'protocol' does not exist on type 'never'... Remove this comment to see the full error message
-    // if (foundAbortController && foundAbortController.protocol === 'WS') {
-    //   console.log('you dummy, you thought you didnt need this');
-    //   api.send('close-ws');
-    // }
-    // this.openConnectionArray = this.openConnectionArray.filter(
-    //   // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type 'never'.
-    //   (obj) => obj.id !== id
-    // );
   },
 
   /* Closes all open endpoint */

--- a/src/client/controllers/reqResController.ts
+++ b/src/client/controllers/reqResController.ts
@@ -217,6 +217,8 @@ const connectionController = {
       reqResObj.request?.method === 'SUBSCRIPTION'
     ) {
       graphQLController.closeSubscription(reqResObj);
+    } else if (/wss?:\/\//.test(reqResObj.protocol)) {
+      api.send('close-ws');
     }
 
     const { id } = reqResObj;


### PR DESCRIPTION
To unsubscribe:

Option 1: Click "Remove" on the workplace container for the given subscription

Option 2:
- Click on "View Response" for the given subscription container
- On the response pane, scroll to the bottom and click "Close Connection"

The biggest challenge is to find a way to store the subscription client in the app, because the client is a function it cannot be stored in traditional databases. We will store it by `ResReq` ID in `graphQLController` instead

E2E tests are updated for coverage.

In addition - add ability to close WebSocket with the `Remove` button in the workspace container

I may consider adding a "Send Request" button to the GraphQL page down the line, but it is out of the scope for this PR.