### PR TITLE
Bug fix: Removing GraphQL from workspace crashes app, app title normalization

### DIFF
--- a/main.js
+++ b/main.js
@@ -116,7 +116,6 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 2000,
     height: 1000,
-    title: 'Swell',
     minWidth: 1000,
     minHeight: 600,
     backgroundColor: '-webkit-linear-gradient(top, #3dadc2 0%,#2f4858 100%)',

--- a/src/client/components/main/GraphQLComposer.tsx
+++ b/src/client/components/main/GraphQLComposer.tsx
@@ -118,89 +118,37 @@ export default function GraphQLComposer(props: $TSFixMe) {
     }
 
     let reqRes;
-    const protocol = url.match(/(https?:\/\/)|(wss?:\/\/)/)[0];
-    // HTTP && GRAPHQL QUERY & MUTATION REQUESTS
-    if (!/wss?:\/\//.test(protocol) && !gRPC) {
-      const URIWithoutProtocol = `${url.split(protocol)[1]}/`;
-      const host = protocol + URIWithoutProtocol.split('/')[0];
-      let path = `/${URIWithoutProtocol.split('/')
-        .splice(1)
-        .join('/')
-        .replace(/\/{2,}/g, '/')}`;
-      if (path.charAt(path.length - 1) === '/' && path.length > 1) {
-        path = path.substring(0, path.length - 1);
-      }
-      path = path.replace(/https?:\//g, 'http://');
-      reqRes = {
-        id: uuid(),
-        createdAt: new Date(),
-        protocol: url.match(/https?:\/\//)[0],
-        host,
-        path,
-        url,
-        graphQL,
-        gRPC,
-        webrtc,
-        timeSent: null,
-        timeReceived: null,
-        connection: 'uninitialized',
-        connectionType: null,
-        checkSelected: false,
-        protoPath,
-        request: {
-          method,
-          headers: headersArr.filter(
-            (header: $TSFixMe) => header.active && !!header.key
-          ),
-          cookies: cookiesArr.filter(
-            (cookie: $TSFixMe) => cookie.active && !!cookie.key
-          ),
-          body: bodyContent || '',
-          bodyType,
-          bodyVariables: bodyVariables || '',
-          rawType,
-          isSSE,
-          network,
-          restUrl,
-          testContent: testContent || '',
-          wsUrl,
-          gqlUrl,
-          grpcUrl,
-        },
-        response: {
-          headers: null,
-          events: null,
-        },
-        checked: false,
-        minimized: false,
-        tab: currentTab,
-      };
-    }
-    // GraphQL Subscriptions
-    const URIWithoutProtocol = `${url.split(protocol)[1]}/`;
-    const host = protocol + URIWithoutProtocol.split('/')[0];
-    let path = `/${URIWithoutProtocol.split('/')
+    const protocol: string = url.match(/(https?:\/\/)|(wss?:\/\/)/)[0];
+    const URIWithoutProtocol: string = `${url.split(protocol)[1]}/`;
+    const host: string = protocol + URIWithoutProtocol.split('/')[0];
+    let path: string = `/${URIWithoutProtocol.split('/')
       .splice(1)
       .join('/')
       .replace(/\/{2,}/g, '/')}`;
     if (path.charAt(path.length - 1) === '/' && path.length > 1) {
       path = path.substring(0, path.length - 1);
     }
-    path = path.replace(/wss?:\//g, 'ws://');
+    path = /wss?:\/\//.test(protocol)
+      ? path.replace(/wss?:\//g, 'ws://')
+      : path.replace(/https?:\//g, 'http://');
     reqRes = {
       id: uuid(),
       createdAt: new Date(),
-      protocol: 'ws://',
+      protocol: /wss?:\/\//.test(protocol)
+        ? 'ws://'
+        : url.match(/https?:\/\//)[0],
       host,
       path,
       url,
       graphQL,
       gRPC,
+      webrtc,
       timeSent: null,
       timeReceived: null,
       connection: 'uninitialized',
       connectionType: null,
       checkSelected: false,
+      protoPath,
       request: {
         method,
         headers: headersArr.filter(
@@ -213,6 +161,7 @@ export default function GraphQLComposer(props: $TSFixMe) {
         bodyType,
         bodyVariables: bodyVariables || '',
         rawType,
+        isSSE,
         network,
         restUrl,
         testContent: testContent || '',

--- a/src/client/components/main/GraphQLComposer.tsx
+++ b/src/client/components/main/GraphQLComposer.tsx
@@ -20,7 +20,7 @@ import TestEntryForm from './new-request/TestEntryForm.jsx';
 
 // Import MUI components
 import { Box } from '@mui/material';
-import { $TSFixMe } from '../../../types';
+import { $TSFixMe, ReqRes } from '../../../types';
 
 // Translated from GraphQLContainer.jsx
 export default function GraphQLComposer(props: $TSFixMe) {
@@ -117,7 +117,6 @@ export default function GraphQLComposer(props: $TSFixMe) {
       return;
     }
 
-    let reqRes;
     const protocol: string = url.match(/(https?:\/\/)|(wss?:\/\/)/)[0];
     const URIWithoutProtocol: string = `${url.split(protocol)[1]}/`;
     const host: string = protocol + URIWithoutProtocol.split('/')[0];
@@ -131,7 +130,7 @@ export default function GraphQLComposer(props: $TSFixMe) {
     path = /wss?:\/\//.test(protocol)
       ? path.replace(/wss?:\//g, 'ws://')
       : path.replace(/https?:\//g, 'http://');
-    reqRes = {
+    const reqRes: ReqRes = {
       id: uuid(),
       createdAt: new Date(),
       protocol: /wss?:\/\//.test(protocol)
@@ -170,8 +169,8 @@ export default function GraphQLComposer(props: $TSFixMe) {
         grpcUrl,
       },
       response: {
-        headers: null,
-        events: null,
+        headers: {},
+        events: [],
       },
       checked: false,
       minimized: false,

--- a/src/client/components/main/http2-composer/Http2Composer.tsx
+++ b/src/client/components/main/http2-composer/Http2Composer.tsx
@@ -25,6 +25,7 @@ import BodyEntryForm from '../new-request/BodyEntryForm';
 import TestEntryForm from '../new-request/TestEntryForm';
 // Import MUI components
 import { Box, FormControlLabel, Switch } from '@mui/material';
+import { CookieOrHeader, ReqRes } from '../../../../types';
 
 // Translated from RestContainer.jsx
 export default function Http2Composer(props) {
@@ -105,6 +106,63 @@ export default function Http2Composer(props) {
     return validationMessage;
   };
 
+  const composeReqRes = (): ReqRes => {
+    const protocol: string = url.match(/(https?:\/\/)/)[0];
+    const URIWithoutProtocol: string = `${url.split(protocol)[1]}/`;
+    const host: string = protocol + URIWithoutProtocol.split('/')[0];
+    let path: string = `/${URIWithoutProtocol.split('/')
+      .splice(1)
+      .join('/')
+      .replace(/\/{2,}/g, '/')}`;
+    if (path.charAt(path.length - 1) === '/' && path.length > 1) {
+      path = path.substring(0, path.length - 1);
+    }
+    path = path.replace(/https?:\//g, 'http://');
+    return {
+      id: uuid(),
+      createdAt: new Date(),
+      protocol: url.match(/https?:\/\//)[0],
+      host,
+      path,
+      url,
+      webrtc,
+      graphQL,
+      gRPC,
+      timeSent: null,
+      timeReceived: null,
+      connection: 'uninitialized',
+      connectionType: null,
+      checkSelected: false,
+      protoPath,
+      request: {
+        method,
+        headers: headersArr.filter(
+          (header: CookieOrHeader) => header.active && !!header.key
+        ),
+        cookies: cookiesArr.filter(
+          (cookie: CookieOrHeader) => cookie.active && !!cookie.key
+        ),
+        body: bodyContent || '',
+        bodyType,
+        bodyVariables: bodyVariables || '',
+        rawType,
+        isSSE,
+        network,
+        restUrl,
+        testContent: testContent || '',
+        wsUrl,
+        gqlUrl,
+        grpcUrl,
+      },
+      response: {
+        headers: {},
+        events: [],
+      },
+      checked: false,
+      minimized: false,
+      tab: currentTab,
+    };
+  };
   /** @todo Figure out what this function does */
   const sendNewRequest = () => {
     const warnings = requestValidationCheck();
@@ -112,63 +170,7 @@ export default function Http2Composer(props) {
       setWarningMessage(warnings);
       return;
     }
-
-    let reqRes;
-    const protocol = url.match(/(https?:\/\/)|(wss?:\/\/)/)[0];
-    // HTTP && GRAPHQL QUERY & MUTATION REQUESTS
-    if (!/wss?:\/\//.test(protocol) && !gRPC) {
-      const URIWithoutProtocol = `${url.split(protocol)[1]}/`;
-      URIWithoutProtocol; // deleteable ???
-      const host = protocol + URIWithoutProtocol.split('/')[0];
-      let path = `/${URIWithoutProtocol.split('/')
-        .splice(1)
-        .join('/')
-        .replace(/\/{2,}/g, '/')}`;
-      if (path.charAt(path.length - 1) === '/' && path.length > 1) {
-        path = path.substring(0, path.length - 1);
-      }
-      path = path.replace(/https?:\//g, 'http://');
-      reqRes = {
-        id: uuid(),
-        createdAt: new Date(),
-        protocol: url.match(/https?:\/\//)[0],
-        host,
-        path,
-        url,
-        webrtc,
-        graphQL,
-        gRPC,
-        timeSent: null,
-        timeReceived: null,
-        connection: 'uninitialized',
-        connectionType: null,
-        checkSelected: false,
-        protoPath,
-        request: {
-          method,
-          headers: headersArr.filter((header) => header.active && !!header.key),
-          cookies: cookiesArr.filter((cookie) => cookie.active && !!cookie.key),
-          body: bodyContent || '',
-          bodyType,
-          bodyVariables: bodyVariables || '',
-          rawType,
-          isSSE,
-          network,
-          restUrl,
-          testContent: testContent || '',
-          wsUrl,
-          gqlUrl,
-          grpcUrl,
-        },
-        response: {
-          headers: null,
-          events: null,
-        },
-        checked: false,
-        minimized: false,
-        tab: currentTab,
-      };
-    }
+    const reqRes: ReqRes = composeReqRes();
 
     // add request to history
     historyController.addHistoryToIndexedDb(reqRes);
@@ -191,65 +193,7 @@ export default function Http2Composer(props) {
       setWarningMessage(warnings);
       return;
     }
-
-    const httpOrWebsocketRegex = /(http|ws)s?:\/\//;
-    const protocol = url.match(httpOrWebsocketRegex)[0];
-
-    let reqRes;
-    // HTTP && GRAPHQL QUERY & MUTATION REQUESTS
-    if (!/wss?:\/\//.test(protocol) && !gRPC) {
-      const URIWithoutProtocol = `${url.split(protocol)[1]}/`;
-      URIWithoutProtocol; // deleteable ???
-      const host = protocol + URIWithoutProtocol.split('/')[0];
-      let path = `/${URIWithoutProtocol.split('/')
-        .splice(1)
-        .join('/')
-        .replace(/\/{2,}/g, '/')}`;
-      if (path.charAt(path.length - 1) === '/' && path.length > 1) {
-        path = path.substring(0, path.length - 1);
-      }
-      path = path.replace(/https?:\//g, 'http://');
-      reqRes = {
-        id: uuid(),
-        createdAt: new Date(),
-        protocol: url.match(/https?:\/\//)[0],
-        host,
-        path,
-        url,
-        webrtc,
-        graphQL,
-        gRPC,
-        timeSent: null,
-        timeReceived: null,
-        connection: 'uninitialized',
-        connectionType: null,
-        checkSelected: false,
-        protoPath,
-        request: {
-          method,
-          headers: headersArr.filter((header) => header.active && !!header.key),
-          cookies: cookiesArr.filter((cookie) => cookie.active && !!cookie.key),
-          body: bodyContent || '',
-          bodyType,
-          bodyVariables: bodyVariables || '',
-          rawType,
-          isSSE,
-          network,
-          restUrl,
-          testContent: testContent || '',
-          wsUrl,
-          gqlUrl,
-          grpcUrl,
-        },
-        response: {
-          headers: null,
-          events: null,
-        },
-        checked: false,
-        minimized: false,
-        tab: currentTab,
-      };
-    }
+    const reqRes: ReqRes = composeReqRes();
 
     // add request to history
     historyController.addHistoryToIndexedDb(reqRes);

--- a/src/client/components/main/new-request/GRPCServiceOrRequestSelect.jsx
+++ b/src/client/components/main/new-request/GRPCServiceOrRequestSelect.jsx
@@ -45,7 +45,7 @@ const GRPCServiceOrRequestSelect = (props) => {
       <div className="dropdown-trigger">
         <button
           id={id}
-          className="button is-small is-outlined is-primary mr-3 add-header-or-cookie-button"
+          className="button is-small is-outlined is-primary mr-3"
           aria-haspopup="true"
           aria-controls="dropdown-menu"
           onClick={() => setDropdownIsActive(!dropdownIsActive)}

--- a/src/client/components/main/new-request/TextCodeArea.tsx
+++ b/src/client/components/main/new-request/TextCodeArea.tsx
@@ -40,7 +40,6 @@ export default function TextCodeArea({
   readOnly = false,
 }: TextCodeAreaProps) {
   const lang: string = mode.substring(mode.indexOf('/') + 1); // Grab language mode based on value passed in
-  console.log(lang);
   return (
     <div className="is-neutral-200-box">
       <CodeMirror

--- a/src/client/controllers/reqResController.ts
+++ b/src/client/controllers/reqResController.ts
@@ -32,7 +32,7 @@ const connectionController = {
     appDispatch(reqResReplaced(reqResArray));
   },
   // listens for reqResUpdate event from main process telling it to update reqResObj REST EVENTS
-  openReqRes(id: number): void {
+  openReqRes(id: number | string): void {
     // remove all previous listeners for 'reqResUpdate' before starting to listen for 'reqResUpdate' again
     api.removeAllListeners('reqResUpdate');
 

--- a/src/client/controllers/reqResController.ts
+++ b/src/client/controllers/reqResController.ts
@@ -208,13 +208,10 @@ const connectionController = {
   },
 
   closeReqRes(reqResObj: ReqRes): void {
-    if (reqResObj.protocol.includes('http')) {
-      api.send('close-http', reqResObj);
-    } else if (
-      reqResObj.graphQL &&
-      reqResObj.request?.method === 'SUBSCRIPTION'
-    ) {
+    if (reqResObj.graphQL && reqResObj.request?.method === 'SUBSCRIPTION') {
       graphQLController.closeSubscription(reqResObj);
+    } else if (reqResObj.protocol.includes('http')) {
+      api.send('close-http', reqResObj);
     } else if (/wss?:\/\//.test(reqResObj.protocol)) {
       api.send('close-ws');
     }

--- a/src/client/toolkit-refactor/reqRes/reqResSlice.ts
+++ b/src/client/toolkit-refactor/reqRes/reqResSlice.ts
@@ -5,28 +5,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ReqRes } from '../../../types';
 
-/**
- * @todo based on current useage type def is innaccurate or incomplete
- * currentReponse stores the last returned ReqRes type
- * in theory currentResponse property is unnessecary as the last element in the
- * reqResArray is the current response but it is used throughout the app
- */
 type ReqResStore = {
   reqResArray: ReqRes[];
-  currentResponse: {
-    request: {
-      network: string;
-    };
-  };
+  currentResponse: ReqRes;
 };
 
 const initialState: ReqResStore = {
   reqResArray: [],
-  currentResponse: {
-    request: {
-      network: '',
-    },
-  },
+  currentResponse: {} as ReqRes,
 };
 
 // export const reqResItemAdded = createAction('reqResItemAdded');
@@ -49,7 +35,7 @@ const reqResSlice = createSlice({
     //previously was REQRES_CLEAR or reqResClear
     reqResCleared(state, _unusedAction: PayloadAction<void>) {
       state.reqResArray = [];
-      state.currentResponse.request.network = '';
+      state.currentResponse = {} as ReqRes;
     },
 
     //previously was REQRES_ADD or reqResAdd

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,21 +165,20 @@ export interface ReqResRequest {
   bodyType: string;
   bodyVariables: string;
   cookies: CookieOrHeader[];
-  graphQL: boolean;
-  gRPC: boolean;
-  gRpcUrl?: string;
+  grpcUrl?: string;
   gqlUrl?: string;
+  isSSE?: boolean;
   headers: CookieOrHeader[];
   method?: string;
   network: Network;
-  protocol: Protocol;
+  rawType: string;
   restUrl?: string;
   testContent: string;
-  testResults: string[];
+  testResults?: string[];
   url?: string;
-  webRtc: boolean;
+  webRtc?: boolean;
   webRtcUrl?: string;
-  ws: boolean;
+  ws?: boolean;
   wsUrl?: string;
 }
 
@@ -276,26 +275,31 @@ export interface OpenAPIReqData {
  */
 export interface ReqRes {
   checked: boolean;
-  closeCode: number;
+  checkSelected: boolean;
+  closeCode?: number;
   connection: ConnectionStatus;
-  connectionType: string;
+  connectionType: string | null;
   createdAt: Date;
-  error: string;
+  error?: string;
   graphQL: boolean;
   gRPC: boolean;
-  id: number;
-  isHTTP2: boolean;
+  host: string;
+  id: string;
+  isHTTP2?: boolean;
   minimized: boolean;
-  openapi: boolean;
+  openapi?: boolean;
   protocol: Protocol;
+  protoPath: string;
+  path: string;
   request: ReqResRequest;
   response: ReqResResponse;
-  rpc: string;
-  service: string;
-  timeReceived: Date | number;
-  timeSent: number;
+  rpc?: string;
+  service?: string;
+  tab: string;
+  timeReceived: Date | number | null;
+  timeSent: number | null;
   url: string;
-  webRtc: boolean;
+  webrtc: boolean;
 }
 
 export interface SSERequest {
@@ -320,13 +324,13 @@ export interface NewRequestStreams {
 
 /**@todo make sure all properties are correct and add any not listed yet*/
 export interface ReqResResponse {
-  cookies: Cookie[];
+  cookies?: Cookie[];
   headers: Record<string, unknown>; //*HAS 'headers' property that is an object - has 'date' property?
   events: Record<string, unknown>[]; // is this the correct type? //*HAS 'events' property that IS an array
-  tab: string; //have not found this property mentioned yet should be removed for seperation of concerns
-  timeSent: number; //should be in 'times' property below instead??
-  timeReceived: number; //should be in 'times' property below instead??
-  url: string; //have not found this property mentioned yet
+  tab?: string; //have not found this property mentioned yet should be removed for seperation of concerns
+  timeSent?: number; //should be in 'times' property below instead??
+  timeReceived?: number; //should be in 'times' property below instead??
+  url?: string; //have not found this property mentioned yet
   /**@todo */ //BELOW - additional properties not sure about yet/that weren't listed here before
   times?: $TSFixMeObject[]; //main_grpcController array of objects {timeSent: Date, timeReceived: Date}
   testResult?: $TSFixMe; //mainprocess main_graphqlController

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,18 +46,6 @@ export type $TSFixMeFunction = (...args: any[]) => any;
  */
 export type $TSFixMeObject = any;
 
-/**
- * Represents any possible valid, serializable JSON value, including values
- * nested to any arbitrary level.
- */
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JsonValue[]
-  | { [key: string]: JsonValue };
-
 export type Protocol = 'http://' | 'ws://';
 export type Network = 'rest' | 'ws' | 'webRtc' | 'graphQL' | 'gRpc' | 'openApi';
 export type ConnectionStatus = 'uninitialized' | 'error' | 'open' | 'closed';
@@ -161,6 +149,10 @@ export type NewRequestFields = {
 };
 
 export interface ReqResRequest {
+  // Currently, the body for WebRTC connection is an object
+  // and typescript does not support union between string and object very well
+  // Ideally we should move the WebRTC body information to a new key value
+  // to fully resolve the issue
   body: string;
   bodyType: string;
   bodyVariables: string;
@@ -188,53 +180,6 @@ export interface ReqResRequest {
 export type IntrospectionData = {
   schemaSDL: string | null;
   clientSchema: GraphQLSchema | null;
-};
-
-/**
- * Defines a whole HTTP request for generating graph data.
- *
- * Type definitions ripped from httpTest file.
- */
-export type HttpRequest = {
-  id: number;
-  /**
-   * createdAt should be formatted like a Date object timestamp. Date objects
-   * are not valid serializable JSON values, and Redux will complain about them
-   */
-  createdAt: string;
-  protocol: string;
-  host: string;
-  path: string;
-  url: string;
-  graphQL: boolean;
-  gRPC: boolean;
-  timeSent: string | null;
-  timeReceived: string | null;
-  connection: string;
-  connectionType: $TSFixMe | null;
-  checkSelected: boolean;
-  protoPath: string | null;
-
-  request: {
-    method: string;
-    headers: $TSFixMeObject[][];
-    cookies: $TSFixMe[];
-    body: string;
-    bodyType: string;
-    bodyVariables: string;
-    rawType: string;
-    isSSE: boolean;
-    network: string;
-    restUrl: string;
-    wsUrl: string;
-    gqlUrl: string;
-    grpcUrl: string;
-  };
-
-  response: { headers: $TSFixMe | null; events: $TSFixMe | null };
-  checked: boolean;
-  minimized: boolean;
-  tab: string;
 };
 
 export interface OpenAPIRequest {
@@ -362,21 +307,6 @@ export interface WindowAPI {
   removeAllListeners: (event: string) => void;
   receive: (event: string, callback: (data: any) => void) => void;
   send: (event: string, data?: any, some?: any) => void;
-}
-
-/**
- * @todo Figure out what these types should be and then implement them
- */
-export interface WRTC {
-  RTCPeerConnection:
-    | RTCPeerConnection
-    | webkitRTCPeerConnection
-    | mozRTCPeerConnection;
-  RTCSessionDescription:
-    | RTCSessionDescription
-    | webkitRTCSessionDescription
-    | mozRTCSessionDescription;
-  RTCIceCandidate: RTCIceCandidate | webkitRTCIceCandidate | mozRTCIceCandidate;
 }
 
 export interface WorkspaceContainerProps {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,13 @@ const CspHtmlWebpackPlugin = require('csp-html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
+// Page title is set in HtmlWebpackPlugin(), and `name` in `package.json`
+// requires all letters to be lower case
+// For consistency with an app that has the first letter of the name
+// as upper case, we will normalize the name here
+const { name } = require('./package.json');
+const title = name.charAt(0).toUpperCase() + name.slice(1);
+
 module.exports = {
   target: 'web',
   resolve: {
@@ -75,10 +82,8 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({}),
     new HtmlWebpackPlugin({
-      // if using template, add <title>Swell</title> and delete line 59.
-      // template: path.resolve(__dirname, "index-csp.html"),
       filename: 'index.html',
-      title: require('./package.json').name,
+      title: title,
 
       /**
        * @todo Update CSP (Content Security Policy) with "nonce" inline styling.


### PR DESCRIPTION
The way that the `reqRes` is setup in `GraphQL` creates an issue where in a query and mutation scenario, the `protocol` is incorrectly hardcoded as `ws://` (i.e. WebSocket) even though the URL starts with `http://`.

This commit rewrites the logic in `GraphQLComposer.tsx` to remove unnecessary redundancies and update `closeReqRes` to ensure GraphQL subscriptions are closed properly

Page title is set in HtmlWebpackPlugin(), and `name` in `package.json` requires all letters to be lower case. For consistency with an app that has the first letter of the name as upper case, we will normalize the name in Webpack instead