### PR TITLE
Fix GraphQL subscription response pane not showing up

### DIFF
--- a/src/client/components/legacy-components/SingleReqResContainer.jsx
+++ b/src/client/components/legacy-components/SingleReqResContainer.jsx
@@ -308,6 +308,10 @@ const SingleReqResContainer = (props) => {
             onClick={() => {
               if (network === 'webrtc') {
                 testSDPConnection(content);
+              } else if (content.graphQL && request.method === 'SUBSCRIPTION') {
+                // For GraphQL subscriptions, `GraphQLController::openSubscription` will take care of
+                // updating state, and we do not want to overwrite response data here
+                connectionController.openReqRes(content.id);
               } else {
                 //if it's http, dispatch set active tab to "event" for reqResResponse
                 //otherwise do nothing

--- a/src/client/components/main/response/ResponsePaneContainer.tsx
+++ b/src/client/components/main/response/ResponsePaneContainer.tsx
@@ -51,7 +51,7 @@ const ResponsePaneContainer = () => {
         {/* HEADER */}
         <div
           className="hero is-primary is-flex is-flex-direction-row is-justify-content-center"
-          style={{ padding: '10px' }}
+          style={{ padding: '10px', position: 'sticky' }}
         >
           <ResponseTime currentResponse={currentResponse} />
           {currentResponse.responseSize && (

--- a/src/client/controllers/graphQLController.ts
+++ b/src/client/controllers/graphQLController.ts
@@ -230,9 +230,7 @@ const graphQLController: GqlController = {
 
     const newReqRes: ReqRes = { ...reqResObj, connection: 'open' };
     appDispatch(reqResUpdated(newReqRes));
-
-    const currentID = Store.getState().reqRes.currentResponse.id;
-    if (currentID === reqResObj.id) appDispatch(responseDataSaved(newReqRes));
+    appDispatch(responseDataSaved(newReqRes));
   },
 
   closeSubscription(reqResObj: ReqRes): void {


### PR DESCRIPTION
Once the GraphQL subscription is initiated, the response container does not show the `Close connection` button right away. This is because the state gets accidentally overwritten in `SingleReqResContainer`. This commit fixes the issue